### PR TITLE
Added 'herb' and 'US/UN' acronym support.

### DIFF
--- a/indefinite_article.gemspec
+++ b/indefinite_article.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   ]
 
   s.require_paths = ["lib"]
+  s.add_dependency 'minitest', '~> 4.7.5'
   s.add_dependency 'activesupport'
   s.add_development_dependency 'i18n'
   s.add_development_dependency 'rake'

--- a/indefinite_article.gemspec
+++ b/indefinite_article.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   ]
 
   s.require_paths = ["lib"]
-  s.add_dependency 'minitest', '~> 4.7.5'
   s.add_dependency 'activesupport'
+  s.add_development_dependency 'minitest', '~> 4.7.5'
   s.add_development_dependency 'i18n'
   s.add_development_dependency 'rake'
 end

--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -3,8 +3,8 @@ require 'active_support/core_ext/string'
 
 module IndefiniteArticle
 
-  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onetime)$|e[uw]|uk|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
-  AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou])/i
+  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onetime)$|e[uw]|uk|ur[aeiou]|us|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
+  AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|herb|hono|honest|hour|heir|[aeiou])/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)
 

--- a/lib/indefinite_article/version.rb
+++ b/lib/indefinite_article/version.rb
@@ -1,3 +1,3 @@
 module IndefiniteArticle
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -9,6 +9,7 @@ class TestIndefiniteArticle < Test::Unit::TestCase
     honor
     honorable
     onerous
+    herb
     hour
     honest
     heir
@@ -34,7 +35,11 @@ class TestIndefiniteArticle < Test::Unit::TestCase
     urinologist
     urea
     b c d g j k p q t u v w y z
-  }
+  } + [
+    'UK angler',
+    'UN citizen',
+    'US ambassador'
+  ]
 
   def setup
   end
@@ -58,8 +63,8 @@ class TestIndefiniteArticle < Test::Unit::TestCase
   end
 
   def test_indefinite_article_selection_case_insensitvity
-    assert_equal "a", "bananna".indefinite_article
-    assert_equal "a", "Bananna".indefinite_article
+    assert_equal "a", "banana".indefinite_article
+    assert_equal "a", "Banana".indefinite_article
     assert_equal "an", "apple".indefinite_article
     assert_equal "an", "Apple".indefinite_article
   end


### PR DESCRIPTION
This patch addresses issue https://github.com/rossmeissl/indefinite_article/issues/7

Version bumped.
