### PR TITLE
Support for digits (e.g., "an 8" or "an 11" vs. "a 4" or "a 5")

### DIFF
--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/string'
 module IndefiniteArticle
 
   A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onetime)$|e[uw]|uk|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
-  AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou])/i
+  AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)
 

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -15,6 +15,7 @@ class TestIndefiniteArticle < Test::Unit::TestCase
     utter
     urgent
     a e f h i l m n o r s x
+    8 11
   }
 
   A_WORDS = %w{
@@ -34,6 +35,7 @@ class TestIndefiniteArticle < Test::Unit::TestCase
     urinologist
     urea
     b c d g j k p q t u v w y z
+    1 2 3 4 5 6 7 9 10 12 13 14 15 16 17 18 19 20
   }
 
   def setup


### PR DESCRIPTION
Adds support for digits:

* "an 8" or "an 11"
* "a 2", "a 3", "a 4", etc.

In our case we want to indefinitize "An 8-hour course" vs. "A 6-hour course".