### PR TITLE
Handle empty string

### DIFF
--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -15,7 +15,7 @@ module IndefiniteArticle
       'an'
     else
       'a'
-    end
+    end unless first_word.nil?
   end
 
   def with_indefinite_article(upcase = false)

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -83,4 +83,8 @@ class TestIndefiniteArticle < Test::Unit::TestCase
   def test_indefinite_article_prefix
     assert_equal 'a banana', 'banana'.with_indefinite_article
   end
+
+  def test_empty_string
+    assert_equal '', ''.indefinitize
+  end
 end


### PR DESCRIPTION
Allow for an empty string to return an empty string instead of raising NoMethodError.  This is helpful when a user defined or dynamic value is indefinitized.