### PR TITLE
Fix minitest + Add/Fix indefinite Word Conditions (ubi*, ubo*, oaxaca*, ouija, unani*)

### DIFF
--- a/indefinite_article.gemspec
+++ b/indefinite_article.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
   s.add_dependency 'activesupport'
+  s.add_development_dependency 'minitest', '~> 5.1'
   s.add_development_dependency 'i18n'
   s.add_development_dependency 'rake'
 end

--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/string'
 
 module IndefiniteArticle
 
-  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onetime)$|e[uw]|uk|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
+  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onetime|ouija)$|e[uw]|uk|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
   AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)

--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/string'
 
 module IndefiniteArticle
 
-  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ub|ufo|ur[aeiou]|use|ut([^t])|unani|uni(l[^l]|[a-ko-z]))/i
+  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ubi|ubo|ufo|ur[aeiou]|use|ut([^t])|unani|uni(l[^l]|[a-ko-z]))/i
   AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)

--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/string'
 
 module IndefiniteArticle
 
-  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ub|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
+  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ub|ufo|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
   AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)

--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/string'
 
 module IndefiniteArticle
 
-  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
+  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ub|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
   AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)

--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/string'
 
 module IndefiniteArticle
 
-  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onetime|ouija)$|e[uw]|uk|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
+  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
   AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)

--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/string'
 
 module IndefiniteArticle
 
-  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
+  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
   AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)

--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/string'
 
 module IndefiniteArticle
 
-  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ub|ufo|ur[aeiou]|use|ut([^t])|uni(l[^l]|[a-ko-z]))/i
+  A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija|oaxaca|oaxacan|oaxacania|oaxacanthaxia)$|e[uw]|uk|ub|ufo|ur[aeiou]|use|ut([^t])|unani|uni(l[^l]|[a-ko-z]))/i
   AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)

--- a/lib/indefinite_article/version.rb
+++ b/lib/indefinite_article/version.rb
@@ -1,3 +1,3 @@
 module IndefiniteArticle
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,9 +1,9 @@
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'indefinite_article'
 
-class Test::Unit::TestCase
+class Minitest::Test
 end

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -25,6 +25,7 @@ class TestIndefiniteArticle < Minitest::Test
     one
     once
     onetime
+    ouija
     european
     ewe
     unicorn

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../helper', __FILE__)
 
-class TestIndefiniteArticle < Test::Unit::TestCase
+class TestIndefiniteArticle < Minitest::Test
   AN_WORDS = %w{
     apple
     unilluminated

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -27,6 +27,7 @@ class TestIndefiniteArticle < Minitest::Test
     oaxacania
     oaxacanthaxia
     one
+    onearmed
     once
     onetime
     ouija

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -33,6 +33,7 @@ class TestIndefiniteArticle < Minitest::Test
     ouija
     european
     ewe
+    ubiquitous
     unicorn
     unilateral
     banana

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -26,6 +26,7 @@ class TestIndefiniteArticle < Minitest::Test
     oaxacan
     oaxacania
     oaxacanthaxia
+    ufo
     one
     onearmed
     once

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -42,7 +42,6 @@ class TestIndefiniteArticle < Minitest::Test
     ewe
     ubiquity
     uboat
-    ubity
     unicorn
     unilateral
     banana

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -22,6 +22,10 @@ class TestIndefiniteArticle < Minitest::Test
     ukulele
     UN
     uk
+    oaxaca
+    oaxacan
+    oaxacania
+    oaxacanthaxia
     one
     once
     onetime

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -4,6 +4,8 @@ class TestIndefiniteArticle < Minitest::Test
   AN_WORDS = %w{
     apple
     unassailable
+    ubuntu
+    ubersexual
     ungrammatical
     unanswered
     unilluminated
@@ -39,6 +41,8 @@ class TestIndefiniteArticle < Minitest::Test
     european
     ewe
     ubiquity
+    uboat
+    ubity
     unicorn
     unilateral
     banana

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -3,6 +3,9 @@ require File.expand_path('../helper', __FILE__)
 class TestIndefiniteArticle < Minitest::Test
   AN_WORDS = %w{
     apple
+    unassailable
+    ungrammatical
+    unanswered
     unilluminated
     unintentional
     unlikely
@@ -27,6 +30,7 @@ class TestIndefiniteArticle < Minitest::Test
     oaxacania
     oaxacanthaxia
     ufo
+    unanimous
     one
     onearmed
     once
@@ -34,7 +38,7 @@ class TestIndefiniteArticle < Minitest::Test
     ouija
     european
     ewe
-    ubiquitous
+    ubiquity
     unicorn
     unilateral
     banana


### PR DESCRIPTION
- Updated Minitest syntax to get the gem's test suite working again.

- Added missing a / an conditions around missing edge cases, [with great help from this list.](http://en.wikipedia.org/wiki/User:Sun_Creator/A_to_An)

- Bump gem version to 0.2.3

Change log:
==========
**'ouija' now indefinitizes to 'a '**
*an ouija* ==> *a ouija*

=====

**'oaxaca*' words now indefinitize to 'a '**
*an oaxaca* ==> *a oaxaca* (city in mexico)
*an oaxacan* ==> *a oxaxacan* (residents of said city)
*an oaxacania* ==> *a oxacania* (flower)
*an oxacanthaxia* ==> *a oxacanthaxia* (beetle)

=====

**'onearmed' now indefinitizes to 'a '**
*an onearmed* ==> *a onearmed*


====
**Words beginning with 'ufo*' now indefinitize to 'a '**

*an ufologist* ==> *a ufologist*

=====

**Words beginning with 'ubi' & 'ubo' now indefinitize to 'a '**

***a:***
*an ubiquity* ==> *a ubiquity*
*an uboat* ==> *a uboat*

**Tests to prevent false positives:**

***an:***
*an ubersexual*  stays  *an ubersexual*
*an ubuntu*  stays  *an ubuntu*

=====
**Words beginning with 'unani*' now indefinitize to 'a '**

***a:***
*an unanimous* ==> *a unanimous*

**Tests to prevent false positives:**

***an:***
*an unanswered*  stays  *an unanswered*
*an unassailable*  stays  *an unassailable*
*an ungrammatical* stays *an ungrammatical*