### PR TITLE
License: add mit license to gemspec

### DIFF
--- a/indefinite_article.gemspec
+++ b/indefinite_article.gemspec
@@ -5,6 +5,7 @@ require "indefinite_article/version"
 Gem::Specification.new do |s|
   s.name        = "indefinite_article"
   s.version     = IndefiniteArticle::VERSION
+  s.licenses    = ['MIT']
   s.authors     = ["Andrew Rossmeissl", 'Shane Brinkman-Davis']
   s.email       = ["andy@rossmeissl.net"]
   s.homepage    = "http://github.com/rossmeissl/indefinite_article"


### PR DESCRIPTION
From what I can tell, the license is an MIT license. 

This allows tools like [License Finder](https://github.com/pivotal/LicenseFinder) to look up this project's metadata.

This also fixes the license display at https://rubygems.org/gems/indefinite_article since it currently says 'N/A'