### PR TITLE
Add "18" to AN_REQUIRING_PATTERNS

### DIFF
--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/string'
 module IndefiniteArticle
 
   A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija)$|e[uw]|uk|ubi|ubo|oaxaca|ufo|ur[aeiou]|use|ut([^t])|unani|uni(l[^l]|[a-ko-z]))/i
-  AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
+  AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11|18)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)
 


### PR DESCRIPTION
For example, you'd want "An 18 point lead" instead of "A 18 point lead".