### PR TITLE
Add 11 and 18 to AN_REQUIRING_PATTERNS, fix for 110

### DIFF
--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/string'
 module IndefiniteArticle
 
   A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija)$|e[uw]|uk|ubi|ubo|oaxaca|ufo|ur[aeiou]|use|ut([^t])|unani|uni(l[^l]|[a-ko-z]))/i
-  AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
+  AN_REQUIRING_PATTERNS = /\b11\b|\b18\b|^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
   UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)
 


### PR DESCRIPTION
I was using this library to generate descriptions based on ages and found that 18 and 110 were incorrectly indefinitized:

``` rb
"18-year-old woman".indefinitize   #=> "a 18-year-old woman"   (incorrect)
"180-year-old statue".indefinitize #=> "a 180-year-old statue" (correct)
"11-year-old house".indefinitize   #=> "an 11-year-old house"  (correct)
"110-year-old house".indefinitize  #=> "an 110-year-old house" (incorrect)
```

I edited the regex pattern for`11`to include `\b` word boundaries so that `110` could be excluded, and included a similar pattern for `18` to correct the cases above.

With this commit, the `\b` boundary would include punctuation for formatted numbers such as `18,000` but not `18000`:

``` rb
"18,000-year-old artifact".indefinitize  #=> "an 18,000-year-old artifact"
"18.000-year-old artifact".indefinitize  #=> "an 18.000-year-old artifact"
"18000-year-old artifact".indefinitize   #=> "a 18000-year-old artifact"
```

I saw pull request #16 and the regex pattern given in the [July 27 comment](https://github.com/rossmeissl/indefinite_article/pull/16#issuecomment-235678908) looks like it could work, as well, but I'm unsure of the status of that PR. That pattern could be a better solution, but I don't know what cases the last block with digit boundaries would match for.

I'd value your feedback if this isn't an appropriate fix, and would be interested in a discussion of a better approach. Thanks!
