### PR TITLE
use 'an' for NDA

### DIFF
--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -6,7 +6,7 @@ module IndefiniteArticle
   A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija)$|e[uw]|uk|ubi|ubo|oaxaca|ufo|ur[aeiou]|use|ut([^t])|unani|uni(l[^l]|[a-ko-z]))/i
   AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
   UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
-  UPCASE_AN_REQUIRING_PATTERNS = /^$/ #need if we decide to support acronyms like "XL" (extra-large)
+  UPCASE_AN_REQUIRING_PATTERNS = /^(NDA)$/ #need if we decide to support acronyms like "XL" (extra-large)
 
   def indefinite_article
     first_word = to_s.split(/[- ]/).first

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -17,6 +17,7 @@ class TestIndefiniteArticle < Minitest::Test
     hour
     honest
     heir
+    NDA
     utter
     urgent
     a e f h i l m n o r s x


### PR DESCRIPTION
We're using this gem at Common Paper and I noticed this while updating a mailer. "An NDA" is more correct than "A NDA"