### PR TITLE
Assume initialisms aren't acronyms by default

### DIFF
--- a/lib/indefinite_article.rb
+++ b/lib/indefinite_article.rb
@@ -5,8 +5,8 @@ module IndefiniteArticle
 
   A_REQUIRING_PATTERNS = /^(([bcdgjkpqtuvwyz]|onc?e|onearmed|onetime|ouija)$|e[uw]|uk|ubi|ubo|oaxaca|ufo|ur[aeiou]|use|ut([^t])|unani|uni(l[^l]|[a-ko-z]))/i
   AN_REQUIRING_PATTERNS = /^([aefhilmnorsx]$|hono|honest|hour|heir|[aeiou]|8|11)/i
-  UPCASE_A_REQUIRING_PATTERNS = /^(UN$)/
-  UPCASE_AN_REQUIRING_PATTERNS = /^(NDA)$/ #need if we decide to support acronyms like "XL" (extra-large)
+  UPCASE_A_REQUIRING_PATTERNS = /^([BCDGJKPQTUVWYZ][A-Z]*$|FEMA|LASER|NAFTA|NATO|SCUBA|SWAT)/
+  UPCASE_AN_REQUIRING_PATTERNS = /^([AEFHILMNORSX][A-Z]*)$/
 
   def indefinite_article
     first_word = to_s.split(/[- ]/).first

--- a/test/test_indefinite_article.rb
+++ b/test/test_indefinite_article.rb
@@ -2,7 +2,9 @@ require File.expand_path('../helper', __FILE__)
 
 class TestIndefiniteArticle < Minitest::Test
   AN_WORDS = %w{
+    AARP
     apple
+    ASAP
     unassailable
     ubuntu
     ubersexual
@@ -13,18 +15,26 @@ class TestIndefiniteArticle < Minitest::Test
     unlikely
     honor
     honorable
+    HRDC
+    IP
     onerous
+    OSHA
     hour
     honest
     heir
     NDA
+    NPC
     utter
     urgent
+    XL
+    XXL
     a e f h i l m n o r s x
     8 11
   }
 
   A_WORDS = %w{
+    3M
+    BBS
     ukulele
     UN
     uk
@@ -38,6 +48,13 @@ class TestIndefiniteArticle < Minitest::Test
     ouija
     european
     ewe
+    FEMA
+    LASER
+    NAFTA
+    NATO
+    PIN
+    SCUBA
+    SWAT
     ubiquity
     uboat
     unicorn
@@ -47,6 +64,7 @@ class TestIndefiniteArticle < Minitest::Test
     useful
     urinologist
     urea
+    VIP
     b c d g j k p q t u v w y z
     1 2 3 4 5 6 7 9 10 12 13 14 15 16 17 18 19 20
   }
@@ -61,14 +79,12 @@ class TestIndefiniteArticle < Minitest::Test
   def test_indefinite_article_selection_for_an
     AN_WORDS.each do |word|
       assert_equal "an", word.indefinite_article, "word: #{word}"
-      assert_equal "an", word.upcase.indefinite_article, "word: #{word.upcase}"
     end
   end
 
   def test_indefinite_article_selection_for_a
     A_WORDS.each do |word|
       assert_equal "a", word.indefinite_article, "word: #{word}"
-      assert_equal "a", word.upcase.indefinite_article, "word: #{word.upcase}"
     end
   end
 


### PR DESCRIPTION
Adds broader support for initialisms. Currently, all initialisms are assumed to be pronounceable (e.g. NAFTA) so the a/an decision uses the same logic as lowercase words, with a list of overrides for non-pronounceable initialisms (e.g. NPC).

But overall it feels like the majority of all-uppercase words will **not** be pronounceable, so IMO the a/an decision should default to how the first letter is pronounced (e.g. "eff" for F), with a list of overrides for pronounceable all-caps words.

(I don't have any data to support that feeling though, so feel free to reject that part and I'll just put in overrides for the words that were causing me trouble 😃 )